### PR TITLE
Fix the validate! error message

### DIFF
--- a/lib/slayer_rails/extensions/form.rb
+++ b/lib/slayer_rails/extensions/form.rb
@@ -10,7 +10,7 @@ module SlayerRails
 
         def validate!
           return if valid?
-          message = errors.full_messages.join(", ")
+          message = errors.full_messages.join(', ')
           raise Slayer::FormValidationError, message unless valid?
         end
 

--- a/lib/slayer_rails/extensions/form.rb
+++ b/lib/slayer_rails/extensions/form.rb
@@ -9,7 +9,9 @@ module SlayerRails
         include ActiveModel::Model
 
         def validate!
-          raise Slayer::FormValidationError, errors unless valid?
+          return if valid?
+          message = errors.full_messages.join(", ")
+          raise Slayer::FormValidationError, message unless valid?
         end
 
         class << self


### PR DESCRIPTION
Currently the `validate!` method returns a serialized instance name with object id, this corrects the behavior to return a comma separated list of errors.

V2 should add a parameter to the initializer `errors` so the error object allows more flexible means of rendering errors