### PR TITLE
Add `to_model`

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.0"
+gem "tzinfo-data"
 
 gemspec path: "../"

--- a/lib/slayer_rails/extensions/form.rb
+++ b/lib/slayer_rails/extensions/form.rb
@@ -6,10 +6,20 @@ module SlayerRails
       extend ActiveSupport::Concern
 
       included do
-        include ActiveModel::Model
+        include ActiveModel::Validations
 
         def validate!
           raise Slayer::FormValidationError, errors unless valid?
+        end
+
+        def to_model(klass, attr_map = nil)
+          all_attrs = klass.new.attributes.keys.map(&:to_sym)
+          return klass.new(attributes.slice(*all_attrs)) if attr_map.nil?
+          attrs = attr_map.inject({}) do |memo, (key, val)|
+            memo[key] = self.send(val)
+            memo
+          end
+          klass.new(attrs)
         end
 
         class << self

--- a/test/fixtures/forms/bad_form.rb
+++ b/test/fixtures/forms/bad_form.rb
@@ -1,0 +1,11 @@
+class BadForm < Slayer::Form
+  attribute :name_and_age, String
+
+  def get_name
+    name_and_age.split(' ').last
+  end
+
+  def get_age
+    name_and_age.split(' ').first.to_i
+  end
+end

--- a/test/lib/form_test.rb
+++ b/test/lib/form_test.rb
@@ -100,6 +100,37 @@ class SlayerRails::FormTest < Minitest::Test
     assert form.invalid?
   end
 
+  def test_simple_to_model
+    person_form = PersonForm.new({ name: 'Luke Skywalker', age: 20 })
+    person = person_form.to_model(Person)
+
+    assert person.is_a? Person
+    assert_equal person.name, person_form.name
+    assert_equal person.age, person_form.age
+  end
+
+  def test_custom_to_model_methods
+    bad_form = BadForm.new({ name_and_age: 'Luke 20' })
+    person = bad_form.to_model(Person, {
+      name: :get_name,
+      age: :get_age,
+    })
+
+    assert person.is_a? Person
+    assert_equal person.name, bad_form.get_name
+    assert_equal person.age, bad_form.get_age
+  end
+
+  def test_custom_to_model_mapping
+    person_form = PersonForm.new({ name: 'Luke Skywalker', age: 20 })
+    person = person_form.to_model(Person, {
+      name: :age,
+    })
+
+    assert person.is_a? Person
+    assert_equal person.name, person_form.age.to_s
+  end
+
   private
 
     def make_params(hash)


### PR DESCRIPTION
Wrong Branch Name:

Add `to_model` to Forms. This takes a klass and an optional remapping object.

The mapping should take the klass's property on the left and the method to call on 'self' on the right.